### PR TITLE
Add CRUD APIs and basic UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from . import models, schemas, database
@@ -7,11 +9,12 @@ from . import models, schemas, database
 models.Base.metadata.create_all(bind=database.engine)
 
 app = FastAPI(title="幼儿园管理系统")
+templates = Jinja2Templates(directory="app/templates")
 
 # 根路由
-@app.get("/")
-def read_root():
-    return {"message": "欢迎使用幼儿园管理系统"}
+@app.get("/", response_class=HTMLResponse)
+def read_root(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
 
 # 依赖项：获取数据库会话
 def get_db():
@@ -34,6 +37,35 @@ def create_teacher(teacher: schemas.TeacherCreate, db: Session = Depends(get_db)
 def list_teachers(db: Session = Depends(get_db)):
     return db.query(models.Teacher).all()
 
+@app.get("/teachers/{teacher_id}", response_model=schemas.Teacher)
+def get_teacher(teacher_id: int, db: Session = Depends(get_db)):
+    teacher = db.query(models.Teacher).get(teacher_id)
+    if not teacher:
+        raise HTTPException(status_code=404, detail="教师不存在")
+    return teacher
+
+@app.put("/teachers/{teacher_id}", response_model=schemas.Teacher)
+def update_teacher(teacher_id: int, teacher: schemas.TeacherUpdate, db: Session = Depends(get_db)):
+    db_teacher = db.query(models.Teacher).get(teacher_id)
+    if not db_teacher:
+        raise HTTPException(status_code=404, detail="教师不存在")
+    if teacher.name is not None:
+        db_teacher.name = teacher.name
+    if teacher.is_external is not None:
+        db_teacher.is_external = teacher.is_external
+    db.commit()
+    db.refresh(db_teacher)
+    return db_teacher
+
+@app.delete("/teachers/{teacher_id}")
+def delete_teacher(teacher_id: int, db: Session = Depends(get_db)):
+    db_teacher = db.query(models.Teacher).get(teacher_id)
+    if not db_teacher:
+        raise HTTPException(status_code=404, detail="教师不存在")
+    db.delete(db_teacher)
+    db.commit()
+    return {"ok": True}
+
 # 学生相关接口
 @app.post("/students/", response_model=schemas.Student)
 def create_student(student: schemas.StudentCreate, db: Session = Depends(get_db)):
@@ -46,6 +78,35 @@ def create_student(student: schemas.StudentCreate, db: Session = Depends(get_db)
 @app.get("/students/", response_model=list[schemas.Student])
 def list_students(db: Session = Depends(get_db)):
     return db.query(models.Student).all()
+
+@app.get("/students/{student_id}", response_model=schemas.Student)
+def get_student(student_id: int, db: Session = Depends(get_db)):
+    student = db.query(models.Student).get(student_id)
+    if not student:
+        raise HTTPException(status_code=404, detail="学生不存在")
+    return student
+
+@app.put("/students/{student_id}", response_model=schemas.Student)
+def update_student(student_id: int, student: schemas.StudentUpdate, db: Session = Depends(get_db)):
+    db_student = db.query(models.Student).get(student_id)
+    if not db_student:
+        raise HTTPException(status_code=404, detail="学生不存在")
+    if student.name is not None:
+        db_student.name = student.name
+    if student.age is not None:
+        db_student.age = student.age
+    db.commit()
+    db.refresh(db_student)
+    return db_student
+
+@app.delete("/students/{student_id}")
+def delete_student(student_id: int, db: Session = Depends(get_db)):
+    db_student = db.query(models.Student).get(student_id)
+    if not db_student:
+        raise HTTPException(status_code=404, detail="学生不存在")
+    db.delete(db_student)
+    db.commit()
+    return {"ok": True}
 
 # 课程相关接口
 @app.post("/courses/", response_model=schemas.Course)
@@ -63,6 +124,38 @@ def create_course(course: schemas.CourseCreate, db: Session = Depends(get_db)):
 def list_courses(db: Session = Depends(get_db)):
     return db.query(models.Course).all()
 
+@app.get("/courses/{course_id}", response_model=schemas.Course)
+def get_course(course_id: int, db: Session = Depends(get_db)):
+    course = db.query(models.Course).get(course_id)
+    if not course:
+        raise HTTPException(status_code=404, detail="课程不存在")
+    return course
+
+@app.put("/courses/{course_id}", response_model=schemas.Course)
+def update_course(course_id: int, course: schemas.CourseUpdate, db: Session = Depends(get_db)):
+    db_course = db.query(models.Course).get(course_id)
+    if not db_course:
+        raise HTTPException(status_code=404, detail="课程不存在")
+    if course.title is not None:
+        db_course.title = course.title
+    if course.teacher_id is not None:
+        teacher = db.query(models.Teacher).get(course.teacher_id)
+        if not teacher:
+            raise HTTPException(status_code=404, detail="教师不存在")
+        db_course.teacher_id = course.teacher_id
+    db.commit()
+    db.refresh(db_course)
+    return db_course
+
+@app.delete("/courses/{course_id}")
+def delete_course(course_id: int, db: Session = Depends(get_db)):
+    db_course = db.query(models.Course).get(course_id)
+    if not db_course:
+        raise HTTPException(status_code=404, detail="课程不存在")
+    db.delete(db_course)
+    db.commit()
+    return {"ok": True}
+
 # 财务记录接口
 @app.post("/finances/", response_model=schemas.FinanceRecord)
 def create_finance(record: schemas.FinanceRecordCreate, db: Session = Depends(get_db)):
@@ -75,3 +168,34 @@ def create_finance(record: schemas.FinanceRecordCreate, db: Session = Depends(ge
 @app.get("/finances/", response_model=list[schemas.FinanceRecord])
 def list_finances(db: Session = Depends(get_db)):
     return db.query(models.FinanceRecord).all()
+
+@app.get("/finances/{record_id}", response_model=schemas.FinanceRecord)
+def get_finance(record_id: int, db: Session = Depends(get_db)):
+    record = db.query(models.FinanceRecord).get(record_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="记录不存在")
+    return record
+
+@app.put("/finances/{record_id}", response_model=schemas.FinanceRecord)
+def update_finance(record_id: int, record: schemas.FinanceRecordUpdate, db: Session = Depends(get_db)):
+    db_record = db.query(models.FinanceRecord).get(record_id)
+    if not db_record:
+        raise HTTPException(status_code=404, detail="记录不存在")
+    if record.amount is not None:
+        db_record.amount = record.amount
+    if record.description is not None:
+        db_record.description = record.description
+    if record.date is not None:
+        db_record.date = record.date
+    db.commit()
+    db.refresh(db_record)
+    return db_record
+
+@app.delete("/finances/{record_id}")
+def delete_finance(record_id: int, db: Session = Depends(get_db)):
+    db_record = db.query(models.FinanceRecord).get(record_id)
+    if not db_record:
+        raise HTTPException(status_code=404, detail="记录不存在")
+    db.delete(db_record)
+    db.commit()
+    return {"ok": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,20 +1,64 @@
-from fastapi import FastAPI, Depends, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, Depends, HTTPException, Request, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
 from sqlalchemy.orm import Session
+from passlib.context import CryptContext
 
 from . import models, schemas, database
 
 # 创建数据库表
 models.Base.metadata.create_all(bind=database.engine)
 
+def init_admin():
+    db = database.SessionLocal()
+    try:
+        if not db.query(models.User).filter_by(username="admin").first():
+            admin = models.User(username="admin", hashed_password=get_password_hash("admin"), role="admin")
+            db.add(admin)
+            db.commit()
+    finally:
+        db.close()
+
 app = FastAPI(title="幼儿园管理系统")
+app.add_middleware(SessionMiddleware, secret_key="very-secret")
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 templates = Jinja2Templates(directory="app/templates")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+init_admin()
 
 # 根路由
 @app.get("/", response_class=HTMLResponse)
 def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/login", response_class=HTMLResponse)
+def login_form(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.post("/login")
+def login(request: Request, username: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.username == username).first()
+    if not user or not verify_password(password, user.hashed_password):
+        return templates.TemplateResponse("login.html", {"request": request, "error": "用户名或密码错误"}, status_code=400)
+    request.session["user_id"] = user.id
+    request.session["username"] = user.username
+    request.session["role"] = user.role
+    return RedirectResponse(url="/", status_code=302)
+
+
+@app.get("/logout")
+def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse(url="/", status_code=302)
 
 # 依赖项：获取数据库会话
 def get_db():
@@ -24,9 +68,22 @@ def get_db():
     finally:
         db.close()
 
+def get_current_user(request: Request, db: Session = Depends(get_db)):
+    user_id = request.session.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="未登录")
+    user = db.query(models.User).get(user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="用户不存在")
+    return user
+
 # 教师相关接口
 @app.post("/teachers/", response_model=schemas.Teacher)
-def create_teacher(teacher: schemas.TeacherCreate, db: Session = Depends(get_db)):
+def create_teacher(
+    teacher: schemas.TeacherCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_teacher = models.Teacher(name=teacher.name, is_external=teacher.is_external)
     db.add(db_teacher)
     db.commit()
@@ -34,18 +91,30 @@ def create_teacher(teacher: schemas.TeacherCreate, db: Session = Depends(get_db)
     return db_teacher
 
 @app.get("/teachers/", response_model=list[schemas.Teacher])
-def list_teachers(db: Session = Depends(get_db)):
+def list_teachers(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     return db.query(models.Teacher).all()
 
 @app.get("/teachers/{teacher_id}", response_model=schemas.Teacher)
-def get_teacher(teacher_id: int, db: Session = Depends(get_db)):
+def get_teacher(
+    teacher_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     teacher = db.query(models.Teacher).get(teacher_id)
     if not teacher:
         raise HTTPException(status_code=404, detail="教师不存在")
     return teacher
 
 @app.put("/teachers/{teacher_id}", response_model=schemas.Teacher)
-def update_teacher(teacher_id: int, teacher: schemas.TeacherUpdate, db: Session = Depends(get_db)):
+def update_teacher(
+    teacher_id: int,
+    teacher: schemas.TeacherUpdate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_teacher = db.query(models.Teacher).get(teacher_id)
     if not db_teacher:
         raise HTTPException(status_code=404, detail="教师不存在")
@@ -58,7 +127,11 @@ def update_teacher(teacher_id: int, teacher: schemas.TeacherUpdate, db: Session 
     return db_teacher
 
 @app.delete("/teachers/{teacher_id}")
-def delete_teacher(teacher_id: int, db: Session = Depends(get_db)):
+def delete_teacher(
+    teacher_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_teacher = db.query(models.Teacher).get(teacher_id)
     if not db_teacher:
         raise HTTPException(status_code=404, detail="教师不存在")
@@ -68,7 +141,11 @@ def delete_teacher(teacher_id: int, db: Session = Depends(get_db)):
 
 # 学生相关接口
 @app.post("/students/", response_model=schemas.Student)
-def create_student(student: schemas.StudentCreate, db: Session = Depends(get_db)):
+def create_student(
+    student: schemas.StudentCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_student = models.Student(name=student.name, age=student.age)
     db.add(db_student)
     db.commit()
@@ -76,18 +153,30 @@ def create_student(student: schemas.StudentCreate, db: Session = Depends(get_db)
     return db_student
 
 @app.get("/students/", response_model=list[schemas.Student])
-def list_students(db: Session = Depends(get_db)):
+def list_students(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     return db.query(models.Student).all()
 
 @app.get("/students/{student_id}", response_model=schemas.Student)
-def get_student(student_id: int, db: Session = Depends(get_db)):
+def get_student(
+    student_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     student = db.query(models.Student).get(student_id)
     if not student:
         raise HTTPException(status_code=404, detail="学生不存在")
     return student
 
 @app.put("/students/{student_id}", response_model=schemas.Student)
-def update_student(student_id: int, student: schemas.StudentUpdate, db: Session = Depends(get_db)):
+def update_student(
+    student_id: int,
+    student: schemas.StudentUpdate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_student = db.query(models.Student).get(student_id)
     if not db_student:
         raise HTTPException(status_code=404, detail="学生不存在")
@@ -100,7 +189,11 @@ def update_student(student_id: int, student: schemas.StudentUpdate, db: Session 
     return db_student
 
 @app.delete("/students/{student_id}")
-def delete_student(student_id: int, db: Session = Depends(get_db)):
+def delete_student(
+    student_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_student = db.query(models.Student).get(student_id)
     if not db_student:
         raise HTTPException(status_code=404, detail="学生不存在")
@@ -110,7 +203,11 @@ def delete_student(student_id: int, db: Session = Depends(get_db)):
 
 # 课程相关接口
 @app.post("/courses/", response_model=schemas.Course)
-def create_course(course: schemas.CourseCreate, db: Session = Depends(get_db)):
+def create_course(
+    course: schemas.CourseCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     teacher = db.query(models.Teacher).filter(models.Teacher.id == course.teacher_id).first()
     if not teacher:
         raise HTTPException(status_code=404, detail="教师不存在")
@@ -121,18 +218,30 @@ def create_course(course: schemas.CourseCreate, db: Session = Depends(get_db)):
     return db_course
 
 @app.get("/courses/", response_model=list[schemas.Course])
-def list_courses(db: Session = Depends(get_db)):
+def list_courses(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     return db.query(models.Course).all()
 
 @app.get("/courses/{course_id}", response_model=schemas.Course)
-def get_course(course_id: int, db: Session = Depends(get_db)):
+def get_course(
+    course_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     course = db.query(models.Course).get(course_id)
     if not course:
         raise HTTPException(status_code=404, detail="课程不存在")
     return course
 
 @app.put("/courses/{course_id}", response_model=schemas.Course)
-def update_course(course_id: int, course: schemas.CourseUpdate, db: Session = Depends(get_db)):
+def update_course(
+    course_id: int,
+    course: schemas.CourseUpdate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_course = db.query(models.Course).get(course_id)
     if not db_course:
         raise HTTPException(status_code=404, detail="课程不存在")
@@ -148,7 +257,11 @@ def update_course(course_id: int, course: schemas.CourseUpdate, db: Session = De
     return db_course
 
 @app.delete("/courses/{course_id}")
-def delete_course(course_id: int, db: Session = Depends(get_db)):
+def delete_course(
+    course_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_course = db.query(models.Course).get(course_id)
     if not db_course:
         raise HTTPException(status_code=404, detail="课程不存在")
@@ -158,7 +271,11 @@ def delete_course(course_id: int, db: Session = Depends(get_db)):
 
 # 财务记录接口
 @app.post("/finances/", response_model=schemas.FinanceRecord)
-def create_finance(record: schemas.FinanceRecordCreate, db: Session = Depends(get_db)):
+def create_finance(
+    record: schemas.FinanceRecordCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_record = models.FinanceRecord(**record.dict())
     db.add(db_record)
     db.commit()
@@ -166,18 +283,30 @@ def create_finance(record: schemas.FinanceRecordCreate, db: Session = Depends(ge
     return db_record
 
 @app.get("/finances/", response_model=list[schemas.FinanceRecord])
-def list_finances(db: Session = Depends(get_db)):
+def list_finances(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     return db.query(models.FinanceRecord).all()
 
 @app.get("/finances/{record_id}", response_model=schemas.FinanceRecord)
-def get_finance(record_id: int, db: Session = Depends(get_db)):
+def get_finance(
+    record_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     record = db.query(models.FinanceRecord).get(record_id)
     if not record:
         raise HTTPException(status_code=404, detail="记录不存在")
     return record
 
 @app.put("/finances/{record_id}", response_model=schemas.FinanceRecord)
-def update_finance(record_id: int, record: schemas.FinanceRecordUpdate, db: Session = Depends(get_db)):
+def update_finance(
+    record_id: int,
+    record: schemas.FinanceRecordUpdate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_record = db.query(models.FinanceRecord).get(record_id)
     if not db_record:
         raise HTTPException(status_code=404, detail="记录不存在")
@@ -192,7 +321,11 @@ def update_finance(record_id: int, record: schemas.FinanceRecordUpdate, db: Sess
     return db_record
 
 @app.delete("/finances/{record_id}")
-def delete_finance(record_id: int, db: Session = Depends(get_db)):
+def delete_finance(
+    record_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
     db_record = db.query(models.FinanceRecord).get(record_id)
     if not db_record:
         raise HTTPException(status_code=404, detail="记录不存在")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -35,3 +35,11 @@ class FinanceRecord(Base):
     amount = Column(Float, nullable=False)
     description = Column(String)
     date = Column(Date)
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    role = Column(String, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -78,6 +78,11 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str
 
+class UserUpdate(BaseModel):
+    username: str | None = None
+    password: str | None = None
+    role: str | None = None
+
 class User(UserBase):
     id: int
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -8,6 +8,10 @@ class TeacherBase(BaseModel):
 class TeacherCreate(TeacherBase):
     pass
 
+class TeacherUpdate(BaseModel):
+    name: str | None = None
+    is_external: bool | None = None
+
 class Teacher(TeacherBase):
     id: int
 
@@ -20,6 +24,10 @@ class StudentBase(BaseModel):
 
 class StudentCreate(StudentBase):
     pass
+
+class StudentUpdate(BaseModel):
+    name: str | None = None
+    age: int | None = None
 
 class Student(StudentBase):
     id: int
@@ -34,6 +42,10 @@ class CourseBase(BaseModel):
 class CourseCreate(CourseBase):
     pass
 
+class CourseUpdate(BaseModel):
+    title: str | None = None
+    teacher_id: int | None = None
+
 class Course(CourseBase):
     id: int
 
@@ -47,6 +59,11 @@ class FinanceRecordBase(BaseModel):
 
 class FinanceRecordCreate(FinanceRecordBase):
     pass
+
+class FinanceRecordUpdate(BaseModel):
+    amount: float | None = None
+    description: str | None = None
+    date: date | None = None
 
 class FinanceRecord(FinanceRecordBase):
     id: int

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -70,3 +70,16 @@ class FinanceRecord(FinanceRecordBase):
 
     class Config:
         orm_mode = True
+
+class UserBase(BaseModel):
+    username: str
+    role: str
+
+class UserCreate(UserBase):
+    password: str
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -13,12 +13,26 @@
 </head>
 <body>
     <h1>幼儿园管理系统</h1>
+    {% if request.session.get('user_id') %}
+        <p>欢迎，{{ request.session.get('username') }} ({{ request.session.get('role') }}) | <a href="/logout">注销</a></p>
+    {% else %}
+        <p><a href="/login">登录</a></p>
+    {% endif %}
+    {% set role = request.session.get('role') %}
     <ul>
         <li><a href="/docs">接口文档</a></li>
+        {% if role in ['admin', 'teacher'] %}
         <li><a href="/teachers/">教师管理</a></li>
+        {% endif %}
+        {% if role in ['admin', 'student'] %}
         <li><a href="/students/">学生管理</a></li>
+        {% endif %}
+        {% if role in ['admin', 'teacher', 'student'] %}
         <li><a href="/courses/">课程管理</a></li>
+        {% endif %}
+        {% if role == 'admin' %}
         <li><a href="/finances/">财务记录</a></li>
+        {% endif %}
     </ul>
 </body>
 </html>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -9,6 +9,7 @@
         ul { list-style: none; padding: 0; }
         li { margin-bottom: 10px; }
         a { text-decoration: none; color: #3498db; }
+        nav { margin-top: 20px; }
     </style>
 </head>
 <body>
@@ -19,6 +20,7 @@
         <p><a href="/login">登录</a></p>
     {% endif %}
     {% set role = request.session.get('role') %}
+    <nav>
     <ul>
         <li><a href="/docs">接口文档</a></li>
         {% if role in ['admin', 'teacher'] %}
@@ -31,8 +33,10 @@
         <li><a href="/courses/">课程管理</a></li>
         {% endif %}
         {% if role == 'admin' %}
+        <li><a href="/users/">用户管理</a></li>
         <li><a href="/finances/">财务记录</a></li>
         {% endif %}
     </ul>
+    </nav>
 </body>
 </html>

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>幼儿园管理系统</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        h1 { color: #2c3e50; }
+        ul { list-style: none; padding: 0; }
+        li { margin-bottom: 10px; }
+        a { text-decoration: none; color: #3498db; }
+    </style>
+</head>
+<body>
+    <h1>幼儿园管理系统</h1>
+    <ul>
+        <li><a href="/docs">接口文档</a></li>
+        <li><a href="/teachers/">教师管理</a></li>
+        <li><a href="/students/">学生管理</a></li>
+        <li><a href="/courses/">课程管理</a></li>
+        <li><a href="/finances/">财务记录</a></li>
+    </ul>
+</body>
+</html>

--- a/backend/app/templates/login.html
+++ b/backend/app/templates/login.html
@@ -4,18 +4,56 @@
     <meta charset="UTF-8">
     <title>登录</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 40px; }
-        form { max-width: 300px; margin: auto; }
-        label { display: block; margin-top: 10px; }
+        body {
+            font-family: Arial, sans-serif;
+            background: #f2f2f2;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .login-box {
+            background: #fff;
+            padding: 40px 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            width: 320px;
+        }
+        .login-box h1 {
+            text-align: center;
+            margin-bottom: 20px;
+            color: #333;
+        }
+        .login-box label {
+            display: block;
+            margin-top: 12px;
+        }
+        .login-box input {
+            width: 100%;
+            padding: 8px;
+            box-sizing: border-box;
+        }
+        .login-box button {
+            width: 100%;
+            margin-top: 20px;
+            padding: 10px;
+            background: #3498db;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>
-    <h1>登录</h1>
-    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
-    <form action="/login" method="post">
-        <label>用户名: <input type="text" name="username"></label>
-        <label>密码: <input type="password" name="password"></label>
-        <button type="submit">登录</button>
-    </form>
+    <div class="login-box">
+        <h1>登录</h1>
+        {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+        <form action="/login" method="post">
+            <label>用户名:<br><input type="text" name="username"></label>
+            <label>密码:<br><input type="password" name="password"></label>
+            <button type="submit">登录</button>
+        </form>
+    </div>
 </body>
 </html>

--- a/backend/app/templates/login.html
+++ b/backend/app/templates/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>登录</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        form { max-width: 300px; margin: auto; }
+        label { display: block; margin-top: 10px; }
+    </style>
+</head>
+<body>
+    <h1>登录</h1>
+    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+    <form action="/login" method="post">
+        <label>用户名: <input type="text" name="username"></label>
+        <label>密码: <input type="password" name="password"></label>
+        <button type="submit">登录</button>
+    </form>
+</body>
+</html>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 sqlalchemy
 psycopg2-binary
 Jinja2
+passlib[bcrypt]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 sqlalchemy
 psycopg2-binary
+Jinja2


### PR DESCRIPTION
## Summary
- add HTML index page for quick navigation
- create update & delete schemas
- implement CRUD routes for teachers, students, courses, and finances
- include Jinja2 in requirements

## Testing
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6845d2ee17fc832e858dc73346a82f60